### PR TITLE
Remove Vipps login

### DIFF
--- a/src/MemberService/Pages/Account/Login.cshtml
+++ b/src/MemberService/Pages/Account/Login.cshtml
@@ -25,8 +25,6 @@
         <hr />
         <vc:external-login return-url="@Model.Input.ReturnUrl"></vc:external-login>
         <hr />
-        <span style="font-size:125%">@Localizer["Innlogging med Vipps fases ut til nyåret"]</span>
-        <hr />
         @Localizer["Du kan lese om hva vi samler av informasjon om deg"] <a asp-page="/Account/Privacy">@Localizer["her"]</a>.
     </div>
 </div>

--- a/src/MemberService/Pages/Account/Login.en.resx
+++ b/src/MemberService/Pages/Account/Login.en.resx
@@ -120,9 +120,6 @@
   <data name="Du kan lese om hva vi samler av informasjon om deg" xml:space="preserve">
     <value>You can read about the information we collect</value>
   </data>
-  <data name="Innlogging med Vipps fases ut til nyåret" xml:space="preserve">
-    <value>Log in with Vipps will become unavailable in 2025.</value>
-  </data>
   <data name="E_post" xml:space="preserve">
     <value>E-mail</value>
   </data>

--- a/src/MemberService/Program.cs
+++ b/src/MemberService/Program.cs
@@ -61,15 +61,6 @@ services
         .GetRequiredService<IUrlHelperFactory>()
         .GetUrlHelper(x.GetRequiredService<IActionContextAccessor>().ActionContext));
 
-services.AddHttpClient("Vipps-auth", client =>
-{
-    client.BaseAddress = new Uri(config.Vipps.BaseUrl);
-    client.DefaultRequestHeaders.Add("client_id", config.Authentication.Vipps.ClientId);
-    client.DefaultRequestHeaders.Add("client_secret", config.Authentication.Vipps.ClientSecret);
-    client.DefaultRequestHeaders.Add("Ocp-Apim-Subscription-Key", config.Vipps.SubscriptionKey);
-    client.Timeout = TimeSpan.FromSeconds(5);
-});
-
 services.AddHttpClient("Vipps", client =>
 {
     client.BaseAddress = new Uri(config.Vipps.BaseUrl);
@@ -157,24 +148,6 @@ services
         options.AppId = config.Authentication.Facebook.AppId;
         options.AppSecret = config.Authentication.Facebook.AppSecret;
         options.AccessDeniedPath = "/account/accessDenied";
-    })
-    .AddOpenIdConnect("Vipps", "Vipps", options =>
-    {
-        options.Authority = $"{config.Vipps.BaseUrl}/access-management-1.0/access/";
-        options.ClientId = config.Authentication.Vipps.ClientId;
-        options.ClientSecret = config.Authentication.Vipps.ClientSecret;
-        options.AccessDeniedPath = "/account/accessDenied";
-        options.CallbackPath = "/signin-vipps";
-        options.ResponseType = "code";
-        options.Scope.Clear();
-        options.Scope.Add("openid");
-        options.Scope.Add("email");
-        options.Scope.Add("name");
-        //options.Scope.Add("api_version_2");
-        options.GetClaimsFromUserInfoEndpoint = true;
-        options.ClaimActions.MapJsonKey(ClaimTypes.Email, "email");
-        options.ClaimActions.MapJsonKey(ClaimTypes.Name, "name");
-        options.ClaimActions.MapJsonKey(ClaimTypes.GivenName, "given_name");
     });
 
 services


### PR DESCRIPTION
To save costs. We want to remove it when the year changes to reduce the risk that someone has an account with a pending membership etc. that they loose access to.

Tested locally, but not with proper integration. Should in particular be reviewed to ensure that vipps payment is not affected.